### PR TITLE
Update Dockerfile for USD v21.02 and Python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@
 # PLATTAR uses this base for other open source projects such as the
 # xrutils toolchain.
 # For more info on USD tools, visit https://github.com/PixarAnimationStudios/USD
-FROM python:2.7.16-slim-buster
+FROM python:3-slim-buster
 
 LABEL MAINTAINER PLATTAR(www.plattar.com)
 
 # our binary versions where applicable
-ENV USD_VERSION="20.08"
+ENV USD_VERSION="21.02"
 
 # Update the environment path
 ENV USD_BUILD_PATH="/usr/src/app/xrutils/usd"


### PR DESCRIPTION
Not sure if you are still maintaining this but it would be great to get an update of this for USD v21.02 using Python3. I ran this successfully to create a docker image (https://hub.docker.com/repository/docker/alankalb/pixar-usd-21.02). Can this be merged and a build added to your docker repo?